### PR TITLE
Add support for private chargers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,4 +45,3 @@ body:
           required: true
         - label: This issue is not a duplicate issue of any [previous issues](https://github.com/cyberjunky/home-assistant-shell_recharge/issues?q=is%3Aissue+label%3A%22Bug%22+)..
           required: true
-  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
     - pylint
 
 default_language_version:
-  python: python3.11
+  python: python3.13
 
 repos:
   - repo: https://github.com/asottile/pyupgrade

--- a/custom_components/shell_recharge/__init__.py
+++ b/custom_components/shell_recharge/__init__.py
@@ -1,22 +1,41 @@
 """The shell_recharge integration."""
+
 from __future__ import annotations
 
 import logging
-from asyncio.exceptions import CancelledError
+from collections import defaultdict
 
 import shellrecharge
-from shellrecharge import LocationEmptyError
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, UPDATE_INTERVAL, SerialNumber
+from .const import DOMAIN
+from .coordinator import (
+    ShellRechargePublicDataUpdateCoordinator,
+    ShellRechargeUserDataUpdateCoordinator,
+)
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating configuration from %s", entry.version)
+
+    if entry.version == 2:
+        new_data = defaultdict(lambda: defaultdict(str), entry.data)
+        new_data["public"]["serial_number"] = new_data["serial_number"]
+        del new_data["serial_number"]
+
+    hass.config_entries.async_update_entry(entry, data=new_data, version=3)
+
+    _LOGGER.debug("Migration to configuration version %s successful", entry.version)
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -26,9 +45,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     api = shellrecharge.Api(websession=async_get_clientsession(hass))
 
-    coordinator = ShellRechargeDataUpdateCoordinator(
-        hass, api, entry.data["serial_number"]
-    )
+    if entry.data.get("public") and entry.data["public"].get("serial_number"):
+        coordinator: DataUpdateCoordinator = ShellRechargePublicDataUpdateCoordinator(
+            hass, api, entry.data["public"]["serial_number"]
+        )
+    else:
+        coordinator = ShellRechargeUserDataUpdateCoordinator(
+            hass,
+            await api.get_user(
+                entry.data["private"]["email"],
+                entry.data["private"]["password"],
+                entry.data["private"].get("api_key"),
+            ),
+        )
+
     hass.data[DOMAIN][entry.entry_id] = coordinator
     await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -45,47 +75,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-class ShellRechargeDataUpdateCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
-    """My custom coordinator."""
-
-    def __init__(
-        self, hass: HomeAssistant, api: shellrecharge.Api, serial_number: SerialNumber
-    ) -> None:
-        """Initialize my coordinator."""
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=UPDATE_INTERVAL,
-        )
-        self.api = api
-        self.serial_number = serial_number
-
-    async def _async_update_data(self) -> shellrecharge.Location | None:
-        """Fetch data from API endpoint.
-
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
-        data = None
-        try:
-            data = await self.api.location_by_id(self.serial_number)
-        except LocationEmptyError:
-            _LOGGER.error(
-                "Error occurred while fetching data for charger(s) %s, not found, or serial is invalid",
-                self.serial_number,
-            )
-        except CancelledError:
-            _LOGGER.error(
-                "CancelledError occurred while fetching data for charger(s) %s",
-                self.serial_number,
-            )
-        except TimeoutError:
-            _LOGGER.error(
-                "TimeoutError occurred while fetching data for charger(s) %s",
-                self.serial_number,
-            )
-
-        return data

--- a/custom_components/shell_recharge/config_flow.py
+++ b/custom_components/shell_recharge/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for shell_recharge integration."""
+
 from __future__ import annotations
 
 from asyncio import CancelledError
@@ -8,31 +9,79 @@ import shellrecharge
 import voluptuous as vol
 from aiohttp.client_exceptions import ClientError
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import section
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 from shellrecharge import LocationEmptyError, LocationValidationError
+from shellrecharge.user import LoginFailedError
 
 from .const import DOMAIN
 
-RECHARGE_SCHEMA = vol.Schema({vol.Required("serial_number"): str})
+RECHARGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("public"): section(
+            vol.Schema(
+                {
+                    vol.Optional("serial_number"): str,
+                }
+            ),
+            {"collapsed": True},
+        ),
+        vol.Optional("private"): section(
+            vol.Schema(
+                {
+                    vol.Optional("email"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.EMAIL)
+                    ),
+                    vol.Optional("password"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
+                }
+            ),
+            {"collapsed": True},
+        ),
+    }
+)
 
 
-class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[misc, call-arg]
+class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for shell_recharge_ev."""
 
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=RECHARGE_SCHEMA)
 
         try:
-            api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
-            await api.location_by_id(user_input["serial_number"])
+            if user_input.get("public") and user_input["public"].get("serial_number"):
+                unique_id = user_input["public"]["serial_number"]
+                api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
+                await api.location_by_id(unique_id)
+            elif (
+                user_input.get("private")
+                and user_input["private"].get("email")
+                and user_input["private"].get("password")
+            ):
+                unique_id = user_input["private"]["email"]
+                api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
+                user = await api.get_user(
+                    email=unique_id,
+                    pwd=user_input["private"]["password"],
+                )
+                user_input["private"]["api_key"] = user.cookies["tnm_api"]
+            else:
+                return self.async_show_form(step_id="user", data_schema=RECHARGE_SCHEMA)
+        except LoginFailedError:
+            errors["base"] = "login_failed"
         except LocationEmptyError:
             errors["base"] = "empty_response"
         except LocationValidationError:
@@ -41,10 +90,10 @@ class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # typ
             errors["base"] = "cannot_connect"
 
         if not errors:
-            await self.async_set_unique_id(user_input["serial_number"])
+            await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured(updates=user_input)
             return self.async_create_entry(
-                title=f"Shell Recharge Charge Point ID {user_input['serial_number']}",
+                title=f"Shell Recharge Charge Point ID {unique_id}",
                 data=user_input,
             )
 

--- a/custom_components/shell_recharge/const.py
+++ b/custom_components/shell_recharge/const.py
@@ -1,7 +1,16 @@
 """Constants for the shell_recharge integration."""
+
 from datetime import timedelta
+from enum import IntFlag
 
 DOMAIN = "shell_recharge"
 SerialNumber = str
 EvseId = str
 UPDATE_INTERVAL = timedelta(minutes=5)
+
+
+class ShellRechargeEntityFeature(IntFlag):
+    """Supported features of the Shell Recharge entity."""
+
+    TOGGLE_SESSION = 1
+    PAY_FOR_ELECTRICITY = 2

--- a/custom_components/shell_recharge/coordinator.py
+++ b/custom_components/shell_recharge/coordinator.py
@@ -1,0 +1,112 @@
+"""Shell Recharge data update coordinators."""
+
+import logging
+from asyncio.exceptions import CancelledError
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from shellrecharge import Api, Location, LocationEmptyError
+from shellrecharge.user import AssetsEmptyError, DetailedChargePointEmptyError, User
+from shellrecharge.usermodels import DetailedAssets
+
+from .const import DOMAIN, UPDATE_INTERVAL, SerialNumber
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ShellRechargeUserDataUpdateCoordinator(DataUpdateCoordinator):
+    """Handles data updates for private chargers."""
+
+    def __init__(self, hass: HomeAssistant, api: User) -> None:
+        """Initialize coordinator."""
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+
+        self.api = api
+
+    async def _async_update_data(self) -> DetailedAssets:
+        """Fetch data from API endpoint.
+
+        Fetches charge point information to cache for entities.
+        """
+        data = None
+        try:
+            data = await self.api.get_detailed_assets()
+        except AssetsEmptyError as exc:
+            _LOGGER.info("User has no charger(s) or card(s)")
+            raise UpdateFailed() from exc
+        except DetailedChargePointEmptyError as exc:
+            _LOGGER.info("User has no charger(s)")
+            raise UpdateFailed() from exc
+        except CancelledError as exc:
+            _LOGGER.error(
+                "CancelledError occurred while fetching user's for charger(s)"
+            )
+            raise UpdateFailed() from exc
+        except TimeoutError as exc:
+            _LOGGER.error("TimeoutError occurred while fetching user's for charger(s)")
+            raise UpdateFailed() from exc
+
+        return data
+
+    async def toggle_session(
+        self, charge_point: str, charge_token: str, toggle: str
+    ) -> bool:
+        """Toggle a charger session."""
+        return bool(
+            await self.api.toggle_charger(
+                charger_id=charge_point, card_rfid=charge_token, action=toggle
+            )
+        )
+
+
+class ShellRechargePublicDataUpdateCoordinator(DataUpdateCoordinator):
+    """My custom coordinator."""
+
+    def __init__(
+        self, hass: HomeAssistant, api: Api, serial_number: SerialNumber
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.api = api
+        self.serial_number = serial_number
+
+    async def _async_update_data(self) -> Location:
+        """Fetch data from API endpoint.
+
+        This is the place to pre-process the data to lookup tables
+        so entities can quickly look up their data.
+        """
+        data = None
+        try:
+            data = await self.api.location_by_id(self.serial_number)
+        except LocationEmptyError as exc:
+            _LOGGER.error(
+                "Error occurred while fetching data for charger(s) %s, not found, or serial is invalid",
+                self.serial_number,
+            )
+            raise UpdateFailed() from exc
+        except CancelledError as exc:
+            _LOGGER.error(
+                "CancelledError occurred while fetching data for charger(s) %s",
+                self.serial_number,
+            )
+            raise UpdateFailed() from exc
+        except TimeoutError as exc:
+            _LOGGER.error(
+                "TimeoutError occurred while fetching data for charger(s) %s",
+                self.serial_number,
+            )
+            raise UpdateFailed() from exc
+
+        return data

--- a/custom_components/shell_recharge/sensor.py
+++ b/custom_components/shell_recharge/sensor.py
@@ -1,4 +1,5 @@
 """Sensors for the shell_recharge integration."""
+
 from __future__ import annotations
 
 import logging
@@ -6,15 +7,24 @@ import typing
 from typing import Any
 
 import shellrecharge
+import voluptuous as vol
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import entity_platform, entity_registry
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from shellrecharge.models import Location
+from shellrecharge.usermodels import DetailedAssets, DetailedChargePoint, DetailedEvse
 
-from . import ShellRechargeDataUpdateCoordinator
-from .const import DOMAIN, EvseId
+from . import (
+    ShellRechargePublicDataUpdateCoordinator,
+    ShellRechargeUserDataUpdateCoordinator,
+)
+from .const import DOMAIN, EvseId, ShellRechargeEntityFeature
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,34 +33,263 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up a shell_recharge_ev sensor entry."""
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        name="toggle_session",
+        schema={
+            vol.Required("card"): str,
+            vol.Required("toggle"): str,
+        },
+        func="toggle_session",
+    )
+
     coordinator = hass.data[DOMAIN][entry.entry_id]
     entities = []
     evse_id = ""
 
     if coordinator.data:
-        for evse in coordinator.data.evses:
-            evse_id = evse.uid
-            sensor = ShellRechargeSensor(evse_id=evse_id, coordinator=coordinator)
-            entities.append(sensor)
+        if isinstance(coordinator, ShellRechargePublicDataUpdateCoordinator):
+            for evse in coordinator.data.evses:
+                evse_id = evse.uid
+                sensor: SensorEntity | BinarySensorEntity = ShellRechargeSensor(
+                    evse_id=evse_id, coordinator=coordinator
+                )
+                entities.append(sensor)
+        else:
+            for charger in coordinator.data.chargePoints:
+                for evse in charger._embedded.evses:  # pylint: disable=protected-access
+                    evse_id = evse.evseId
+                    sensor = ShellRechargePrivateSensor(
+                        evse_id=evse_id, coordinator=coordinator
+                    )
+                    entities.append(sensor)
+            for card in coordinator.data.chargeTokens:
+                sensor = ShellCardSensor(card_id=card.uuid, coordinator=coordinator)
+                entities.append(sensor)
 
         async_add_entities(entities, True)
 
 
+class ShellRechargePrivateSensor(
+    CoordinatorEntity[ShellRechargeUserDataUpdateCoordinator],
+    SensorEntity,
+):
+    """This sensor represent a private charger."""
+
+    def __init__(
+        self, evse_id: EvseId, coordinator: ShellRechargeUserDataUpdateCoordinator
+    ) -> None:
+        """Initialize the Sensor."""
+        super().__init__(coordinator)
+        self.evse_id = evse_id
+        self.coordinator = coordinator
+        self.charger = self._get_charger()
+        self.evse = self._get_evse()
+        self._attr_unique_id = f"{evse_id}-charger"
+        self._attr_attribution = "shellrecharge.com"
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_native_unit_of_measurement = None
+        self._attr_state_class = None
+        self._attr_has_entity_name = False
+        self._attr_name = f"{self.charger.name} {self.charger.address.street} {self.charger.address.number} {self.charger.address.city}"
+        self._attr_device_info = DeviceInfo(
+            name=self._attr_name,
+            identifiers={(DOMAIN, self._attr_name)},
+            entry_type=None,
+            manufacturer=self.charger.vendor,
+            model=self.charger.model,
+        )
+        self._attr_options = list(
+            typing.get_args(shellrecharge.usermodels.ChargePointDetailedStatus)
+        )
+        self._attr_supported_features = ShellRechargeEntityFeature.TOGGLE_SESSION
+        self._read_coordinator_data()
+
+    def _get_charger(self) -> DetailedChargePoint:
+        assets: DetailedAssets = self.coordinator.data
+        if assets:
+            for charger in assets.chargePoints:
+                for evse in charger._embedded.evses:  # pylint: disable=protected-access
+                    if evse.evseId == self.evse_id:
+                        return charger
+        raise HomeAssistantError()
+
+    def _get_evse(self) -> DetailedEvse:
+        assets: DetailedAssets = self.coordinator.data
+        if assets:
+            for charger in assets.chargePoints:
+                for evse in charger._embedded.evses:  # pylint: disable=protected-access
+                    if evse.evseId == self.evse_id:
+                        return evse
+        raise HomeAssistantError()
+
+    def _read_coordinator_data(self) -> None:
+        """Read data frem shell recharge charger."""
+        _LOGGER.debug(self.charger)
+
+        try:
+            if self.charger and self.evse:
+                self._attr_native_value = self.evse.status
+                self._attr_icon = "mdi:ev-plug-type2"
+                connector = self.evse.connectors[0]
+                extra_data = {
+                    "connector_power_type": connector.electricCurrentType,
+                    "connector_max_current": connector.maxCurrentInAmps,
+                    "connector_max_power": connector.maxPowerInWatts,
+                    "connector_phases": connector.numberOfPhases,
+                    "evse_id": self.evse.evseId,
+                    "evse_uuid": self.evse.id,
+                    "city": self.charger.address.city,
+                    "country": self.charger.address.country,
+                    "number": self.charger.address.number,
+                    "street": self.charger.address.street,
+                    "zip": self.charger.address.zip,
+                    "connectivity": self.charger.connectivity,
+                    "longitude": self.charger.coordinates.longitude,
+                    "latitude": self.charger.coordinates.latitude,
+                    "uuid": self.charger.id,
+                    "model": self.charger.model,
+                    "name": self.charger.name,
+                    "plug_and_charge_capable": self.charger.plugAndCharge.capable,
+                    "serial": self.charger.serial,
+                    "sharing": self.charger.sharing,
+                    "vendor": self.charger.vendor,
+                }
+                if self.evse.statusDetails.rfid:
+                    extra_data["connected_card_rfid"] = self.evse.statusDetails.rfid
+                if self.evse.statusDetails.printedNumber:
+                    extra_data[
+                        "connected_card_number"
+                    ] = self.evse.statusDetails.printedNumber
+                self._attr_extra_state_attributes = extra_data
+
+        except AttributeError as err:
+            _LOGGER.error(err)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._read_coordinator_data()
+        self.async_write_ha_state()
+
+    async def toggle_session(self, **kwargs: str) -> bool:
+        """Handle the service call to toggle the charge point session."""
+        toggle = kwargs.get("toggle", "")
+        if toggle not in ["start", "stop"]:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_toggle",
+                translation_placeholders={"toggle": toggle},
+            )
+
+        card = kwargs.get("card", "")
+        if not card:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_card",
+                translation_placeholders={"card": card},
+            )
+        registry = entity_registry.async_get(self.hass)
+        card_entity = registry.async_get(card)
+        if not card_entity:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_card",
+                translation_placeholders={"card": card},
+            )
+        uuid = card_entity.unique_id
+
+        # Solely doing it like this since I'm more confident in the uniqueness
+        # of the card's uuid than its rfid.
+        assets: DetailedAssets = self.coordinator.data
+        rfid = next(
+            iter([token.rfid for token in assets.chargeTokens if token.uuid == uuid]),
+            None,
+        )
+        if not rfid:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_card",
+                translation_placeholders={"card": card},
+            )
+
+        success = await self.coordinator.toggle_session(self.charger.id, rfid, toggle)
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="session_toggle",
+                translation_placeholders={
+                    "action": toggle,
+                    "charger": self.charger.id,
+                    "card": rfid,
+                },
+            )
+        return True
+
+
+class ShellCardSensor(
+    CoordinatorEntity[ShellRechargeUserDataUpdateCoordinator],
+    BinarySensorEntity,
+):
+    """This sensor represent a charge card."""
+
+    def __init__(
+        self, card_id: str, coordinator: ShellRechargeUserDataUpdateCoordinator
+    ) -> None:
+        """Initialize the Sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self.card_id = card_id
+        self.card = self._get_card()
+        self._attr_unique_id = self.card.uuid
+        self._attr_attribution = "shellrecharge.com"
+        # self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_native_unit_of_measurement = None
+        self._attr_state_class = None
+        self._attr_has_entity_name = False
+        self._attr_name = self.card.name
+        self._attr_device_info = DeviceInfo(
+            name=self._attr_name,
+            identifiers={(DOMAIN, str(self._attr_name))},
+            entry_type=None,
+            manufacturer="Shell",
+        )
+        self._attr_is_on = True
+        # self._attr_options = ["enabled"]
+        # self._attr_native_value = "enabled"
+        self._attr_icon = "mdi:account-credit-card"
+        self._attr_supported_features = ShellRechargeEntityFeature.PAY_FOR_ELECTRICITY
+        self._attr_extra_state_attributes = {
+            "rfid": self.card.rfid,
+            "printed_number": self.card.printedNumber,
+        }
+
+    def _get_card(self) -> shellrecharge.usermodels.ChargeToken:
+        assets: DetailedAssets = self.coordinator.data
+        if assets:
+            for card in assets.chargeTokens:
+                if card.uuid == self.card_id:
+                    return card
+        raise HomeAssistantError()
+
+
 class ShellRechargeSensor(
-    CoordinatorEntity[ShellRechargeDataUpdateCoordinator], SensorEntity  # type: ignore
+    CoordinatorEntity[ShellRechargePublicDataUpdateCoordinator],
+    SensorEntity,
 ):
     """Main feature of this integration. This sensor represents an EVSE and shows its realtime availability status."""
 
     def __init__(
         self,
         evse_id: EvseId,
-        coordinator: ShellRechargeDataUpdateCoordinator,
+        coordinator: ShellRechargePublicDataUpdateCoordinator,
     ) -> None:
         """Initialize the Sensor."""
         super().__init__(coordinator)
         self.evse_id = evse_id
         self.coordinator = coordinator
-        self.location = self.coordinator.data
+        self.location: Location = self.coordinator.data
         self._attr_unique_id = f"{evse_id}-charger"
         self._attr_attribution = "shellrecharge.com"
         self._attr_device_class = SensorDeviceClass.ENUM
@@ -66,13 +305,14 @@ class ShellRechargeSensor(
             name=self._attr_name,
             identifiers={(DOMAIN, self._attr_name)},
             entry_type=None,
+            manufacturer=operator,
         )
         self._attr_options = list(typing.get_args(shellrecharge.models.Status))
         self._read_coordinator_data()
 
     def _get_evse(self) -> Any:
-        if self.coordinator.data:
-            for evse in self.coordinator.data.evses:
+        if self.location:
+            for evse in self.location.evses:
                 if evse.uid == self.evse_id:
                     return evse
         return None
@@ -137,7 +377,7 @@ class ShellRechargeSensor(
         except AttributeError as err:
             _LOGGER.error(err)
 
-    @callback  # type: ignore
+    @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._read_coordinator_data()

--- a/custom_components/shell_recharge/services.yaml
+++ b/custom_components/shell_recharge/services.yaml
@@ -1,0 +1,33 @@
+toggle_session:
+  name: Toggle charger session
+  description: Start/stop a charging session
+  target:
+    entity:
+      integration: shell_recharge
+      # Home Assistant does not support filtering on custom features
+      supported_features:
+        - climate.ClimateEntityFeature.TARGET_TEMPERATURE
+        # - shell_recharge.ShellRechargeEntityFeature.TOGGLE_SESSION
+  fields:
+    card:
+      name: Card
+      description: Charge card to use for the session
+      required: True
+      selector:
+        entity:
+          filter:
+            integration: shell_recharge
+            # supported_features:
+            #  - climate.ClimateEntityFeature.TARGET_TEMPERATURE
+            #  - shell_recharge.ShellRechargeEntityFeature.PAY_FOR_ELECTRICITY
+    toggle:
+      name: Action
+      description: Whether you want to stop or start a session
+      example: start
+      default: start
+      required: True
+      selector:
+        select:
+          options:
+            - start
+            - stop

--- a/custom_components/shell_recharge/strings.json
+++ b/custom_components/shell_recharge/strings.json
@@ -6,14 +6,39 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "empty_response": "Empty reponse from shellrecharge.com. Either invalid SERIAL-NUMBER or no data found for it.",
+      "login_failed": "Login failed, please verify email and password are correct.",
       "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "data": {
-          "serial_number": "SERIAL-NUMBER (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)"
-        }
+        "sections": {
+          "private": {
+            "data": {
+              "email": "Shell Recharge account e-mail address",
+              "password": "Shell Recharge account password"
+            },
+            "name": "Private charge point"
+          },
+          "public": {
+            "data": {
+              "serial_number": "SERIAL-NUMBER (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)"
+            },
+            "name": "Public charge point"
+          }
+        },
+        "title": "Configure a public or private charge point"
       }
+    }
+  },
+  "exceptions": {
+    "invalid_card": {
+      "message": "Invalid card selected. Got {card}"
+    },
+    "invalid_toggle": {
+      "message": "Invalid toggle selected, expected ['start', 'stop']. Got {toggle}"
+    },
+    "session_toggle": {
+      "message": "Could not {toggle} session on {charger} with {rfid}."
     }
   }
 }

--- a/custom_components/shell_recharge/translations/en.json
+++ b/custom_components/shell_recharge/translations/en.json
@@ -6,14 +6,39 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "empty_response": "Empty reponse from shellrecharge.com. Either invalid SERIAL-NUMBER or no data found for it.",
+      "login_failed": "Login failed, please verify email and password are correct.",
       "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "data": {
-          "serial_number": "SERIAL-NUMBER (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)"
-        }
+        "sections": {
+          "private": {
+            "data": {
+              "email": "Shell Recharge account e-mail address",
+              "password": "Shell Recharge account password"
+            },
+            "name": "Private charge point"
+          },
+          "public": {
+            "data": {
+              "serial_number": "SERIAL-NUMBER (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)"
+            },
+            "name": "Public charge point"
+          }
+        },
+        "title": "Configure a public or private charge point"
       }
+    }
+  },
+  "exceptions": {
+    "invalid_card": {
+      "message": "Invalid card selected. Got {card}"
+    },
+    "invalid_toggle": {
+      "message": "Invalid toggle selected, expected ['start', 'stop']. Got {toggle}"
+    },
+    "session_toggle": {
+      "message": "Could not {toggle} session on {charger} with {rfid}."
     }
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 colorlog==6.9.0
-homeassistant==2024.1.0
+homeassistant==2025.4.4
 mypy==1.15.0
-pre-commit==4.1.0
 pip>=21.0,<25.1
-pylint==3.3.4
-ruff==0.11.0
-shellrecharge==0.1.18
+pre-commit==4.2.0
+pylint==3.3.6
+ruff==0.11.7
+shellrecharge==0.1.20
 types-cachetools
 vulture==2.14

--- a/scripts/lint
+++ b/scripts/lint
@@ -6,4 +6,4 @@ cd "$(dirname "$0")/.."
 
 pre-commit install-hooks;
 pre-commit run --hook-stage manual --all-files;
-vulture . --min-confidence 65 --ignore-names policy
+vulture . --min-confidence 65 --ignore-names policy --exclude "*/.venv/*,*/venv/*"


### PR DESCRIPTION
A couple of points of note:
- This requires 0.1.20 of python-shellrecharge which is yet to be pushed to pypi
- The config flow is a little sub-optimal imo, in the current version of home assistant you can no longer make fields of an optional section required. If you do, it complains about missing fields. This used to work in the 2024 version but seems broken now
- Entity field feature filtering in the services.yaml is utterly broken. Only target entity feature filtering works, but only if you reference a supported core feature with the same enum value af the feature you're targetting. Brittle, but it works. Entity field feature filtering however I was completely unable to get working at all. You can filter the entities down to only show the ones linked to the integration, but further targeting of a specific feature does not work, no idea what goes wrong. I left the filter in comment, feel free to try it out
- I'm not super happy about the BinarySensors for the charge cards, but I didn't really find anything else that would fit better.