### PR TITLE
Migrate public chargers to official Shell EV API (api.shell.com/ev/v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,17 @@ All sensors are created by default and grouped under a single device for easy ma
 
 For public EV chargers:
 
-- **Charger Serial Number**
+- **Shell Developer API credentials** — register a free account at [developer.shell.com](https://developer.shell.com) and create an application to obtain a **Client ID** and **Client Secret**.
+- **Location external ID** (the UUID-format serial number of the charger, e.g. `0F80EA26-5F5D-4728-B5E5-268BE55B9191`). You can find this on the [Shell Recharge map](https://shellrecharge.com/en-gb/solutions/for-drivers/driver-map).
 
-Look up the Serial Number here: https://ui-map.shellrecharge.com (inside details section).
+> [!NOTE]
+> The integration now uses the **official Shell EV API** (`api.shell.com/ev/v1`).
+> The old unofficial map API (`ui-map.shellrecharge.com`) has been discontinued.
+> Developer credentials are required but registration is free.
 
 For private EV chargers:
 
-- **Your Shell Recharge account details**
+- **Your Shell Recharge account details** (email and password)
 
 ## Installation
 
@@ -159,10 +163,14 @@ Alternatively:
 2. Click **+ Add Integration**
 3. Search for **"Shell Recharge"**
 4. Select **"Public Charger"**
-5. Enter the **Serial Number** of the charger
+5. Enter:
+   - **Location external ID** (UUID-format serial number)
+   - **Client ID** from developer.shell.com
+   - **Client Secret** from developer.shell.com
 
 > [!TIP]
-> Find the Serial Number on [Shell Recharge Map](https://ui-map.shellrecharge.com) - click on a charger and look in the details section.
+> Register for free API credentials at [developer.shell.com](https://developer.shell.com).
+> The location external ID is the UUID identifier for a charger location (e.g. `0F80EA26-5F5D-4728-B5E5-268BE55B9191`).
 
 The integration creates a sensor for the charger status with all location, tariff, and connector attributes.
 

--- a/custom_components/shell_recharge/__init__.py
+++ b/custom_components/shell_recharge/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import ShellEvApi
 from .const import DOMAIN
 from .coordinator import (
     ShellRechargePublicDataUpdateCoordinator,
@@ -22,18 +23,20 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
-    _LOGGER.debug("Migrating configuration from %s", entry.version)
+    _LOGGER.debug("Migrating configuration from version %s", entry.version)
 
     if entry.version == 2:
         new_data = dict(entry.data)
         new_data["public"] = {"serial_number": new_data.pop("serial_number")}
-    else:
-        return True
+        hass.config_entries.async_update_entry(entry, data=new_data, version=3)
 
-    hass.config_entries.async_update_entry(entry, data=new_data, version=3)
+    if entry.version == 3:
+        # v3 public entries lack client_id/client_secret; keep data as-is.
+        # The coordinator will raise UpdateFailed with a helpful message when
+        # credentials are missing so the user knows to reconfigure.
+        hass.config_entries.async_update_entry(entry, version=4)
 
     _LOGGER.debug("Migration to configuration version %s successful", entry.version)
-
     return True
 
 
@@ -42,20 +45,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    api = shellrecharge.Api(websession=async_get_clientsession(hass))
-
     coordinator: ShellRechargePublicDataUpdateCoordinator | ShellRechargeUserDataUpdateCoordinator
-    if entry.data.get("public") and entry.data["public"].get("serial_number"):
+
+    pub = entry.data.get("public") or {}
+    if pub.get("serial_number"):
+        api = ShellEvApi(
+            websession=async_get_clientsession(hass),
+            client_id=pub.get("client_id", ""),
+            client_secret=pub.get("client_secret", ""),
+        )
         coordinator = ShellRechargePublicDataUpdateCoordinator(
-            hass, api, entry.data["public"]["serial_number"]
+            hass, api, pub["serial_number"]
         )
     else:
+        priv = entry.data.get("private") or {}
+        shell_api = shellrecharge.Api(websession=async_get_clientsession(hass))
         coordinator = ShellRechargeUserDataUpdateCoordinator(
             hass,
-            await api.get_user(
-                entry.data["private"]["email"],
-                entry.data["private"]["password"],
-                entry.data["private"].get("api_key"),
+            await shell_api.get_user(
+                priv["email"],
+                priv["password"],
+                priv.get("api_key"),
             ),
         )
 

--- a/custom_components/shell_recharge/api.py
+++ b/custom_components/shell_recharge/api.py
@@ -1,0 +1,276 @@
+"""Async client for the official Shell EV API (api.shell.com/ev/v1)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientError
+
+_LOGGER = logging.getLogger(__name__)
+
+OAUTH_URL = "https://api.shell.com/v2/oauth/token"
+API_BASE = "https://api.shell.com/ev/v1"
+
+
+class ShellEvApiError(Exception):
+    """Base exception for Shell EV API errors."""
+
+
+class ShellEvAuthError(ShellEvApiError):
+    """Raised when OAuth2 authentication fails."""
+
+
+class ShellEvLocationNotFoundError(ShellEvApiError):
+    """Raised when a location cannot be found."""
+
+
+@dataclass
+class ElectricalProperties:
+    """Connector electrical properties."""
+
+    powerType: str = ""
+    voltage: float = 0.0
+    amperage: float = 0.0
+    maxElectricPower: float = 0.0
+
+
+@dataclass
+class Tariff:
+    """Connector tariff information."""
+
+    startFee: float = 0.0
+    perMinute: float = 0.0
+    perKWh: float = 0.0
+    currency: str = ""
+    updated: str = ""
+    updatedBy: str = ""
+    structure: str = ""
+
+
+@dataclass
+class Connector:
+    """Single connector on an EVSE."""
+
+    uid: int = 0
+    externalId: str = ""
+    connectorType: str = "Unspecified"
+    electricalProperties: ElectricalProperties = field(default_factory=ElectricalProperties)
+    fixedCable: bool = False
+    tariff: Tariff = field(default_factory=Tariff)
+
+
+@dataclass
+class Evse:
+    """Electric Vehicle Supply Equipment unit."""
+
+    uid: int = 0
+    externalId: str = ""
+    evseId: str = ""
+    status: str = "Unknown"
+    connectors: list[Connector] = field(default_factory=list)
+
+
+@dataclass
+class Coordinates:
+    """Geographic coordinates."""
+
+    latitude: float = 0.0
+    longitude: float = 0.0
+
+
+@dataclass
+class Address:
+    """Location address."""
+
+    streetAndNumber: str = ""
+    postalCode: str = ""
+    city: str = ""
+    country: str = ""
+
+
+@dataclass
+class AccessibilityV2:
+    """Accessibility status."""
+
+    status: str = ""
+
+
+@dataclass
+class Location:
+    """Shell Recharge charging location with one or more EVSEs."""
+
+    uid: int = 0
+    externalId: str = ""
+    coordinates: Coordinates = field(default_factory=Coordinates)
+    operatorName: str = ""
+    address: Address = field(default_factory=Address)
+    evses: list[Evse] = field(default_factory=list)
+    accessibilityV2: AccessibilityV2 = field(default_factory=AccessibilityV2)
+    suboperatorName: str = ""
+    supportPhoneNumber: str = ""
+    openTwentyFourSeven: bool = True
+
+
+# Status values returned by the Shell EV API
+EVSE_STATUS_OPTIONS = ["Available", "Occupied", "Unavailable", "Unknown"]
+
+
+class ShellEvApi:
+    """Async client for the Shell EV public locations API."""
+
+    def __init__(
+        self,
+        websession: ClientSession,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        """Initialise with aiohttp session and OAuth2 credentials."""
+        self._session = websession
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._access_token: str | None = None
+        self._token_expires_at: datetime = datetime.min
+
+    async def _get_token(self) -> str:
+        """Return a valid Bearer token, fetching a new one when expired."""
+        if self._access_token and datetime.now() < self._token_expires_at:
+            return self._access_token
+
+        _LOGGER.debug("Fetching new Shell EV API OAuth2 token")
+        try:
+            async with self._session.post(
+                OAUTH_URL,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+                headers={"Accept": "application/json"},
+                timeout=None,
+            ) as resp:
+                if resp.status in (401, 403):
+                    raise ShellEvAuthError(
+                        "Invalid client_id or client_secret. "
+                        "Register at developer.shell.com to obtain credentials."
+                    )
+                resp.raise_for_status()
+                data = await resp.json()
+        except ClientError as err:
+            raise ShellEvApiError(f"Network error fetching OAuth token: {err}") from err
+
+        self._access_token = data["access_token"]
+        expires_in = int(data.get("expires_in", 3600))
+        # Refresh 60 s before expiry to avoid edge-case failures
+        self._token_expires_at = datetime.now() + timedelta(seconds=max(expires_in - 60, 0))
+        return self._access_token
+
+    async def location_by_id(self, location_id: str) -> Location:
+        """Return a Location by its external ID (serial number).
+
+        Searches the /locations endpoint filtered by locationExternalId.
+        """
+        token = await self._get_token()
+        request_id = str(uuid.uuid4())
+
+        _LOGGER.debug("Fetching Shell EV location for external ID %s", location_id)
+        try:
+            async with self._session.get(
+                f"{API_BASE}/locations",
+                params={"locationExternalId": location_id, "perPage": 1},
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "RequestId": request_id,
+                    "Accept": "application/json",
+                },
+                timeout=None,
+            ) as resp:
+                if resp.status == 401:
+                    # Token may have been revoked; clear cache and raise
+                    self._access_token = None
+                    raise ShellEvAuthError("Bearer token rejected by API")
+                if resp.status == 404:
+                    raise ShellEvLocationNotFoundError(
+                        f"Location with external ID '{location_id}' not found"
+                    )
+                resp.raise_for_status()
+                result = await resp.json()
+        except ClientError as err:
+            raise ShellEvApiError(f"Network error fetching location: {err}") from err
+
+        items: list[dict] = result.get("data", [])
+        if not items:
+            raise ShellEvLocationNotFoundError(
+                f"No location returned for external ID '{location_id}'"
+            )
+
+        return self._parse_location(items[0])
+
+    # ------------------------------------------------------------------
+    # Internal parsing helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_connector(data: dict) -> Connector:
+        ep = data.get("electricalProperties") or {}
+        tariff_data = data.get("tariff") or {}
+        return Connector(
+            uid=data.get("uid", 0),
+            externalId=data.get("externalId", ""),
+            connectorType=data.get("connectorType", "Unspecified"),
+            electricalProperties=ElectricalProperties(
+                powerType=ep.get("powerType", ""),
+                voltage=float(ep.get("voltage", 0)),
+                amperage=float(ep.get("amperage", 0)),
+                maxElectricPower=float(ep.get("maxElectricPower", 0)),
+            ),
+            fixedCable=bool(data.get("fixedCable", False)),
+            tariff=Tariff(
+                startFee=float(tariff_data.get("startFee", 0)),
+                perMinute=float(tariff_data.get("perMinute", 0)),
+                perKWh=float(tariff_data.get("perKWh", 0)),
+                currency=tariff_data.get("currency", ""),
+                updated=tariff_data.get("updated", ""),
+                updatedBy=tariff_data.get("updatedBy", ""),
+                structure=tariff_data.get("structure", ""),
+            ),
+        )
+
+    def _parse_evse(self, data: dict) -> Evse:
+        return Evse(
+            uid=data.get("uid", 0),
+            externalId=data.get("externalId", ""),
+            evseId=data.get("evseId", ""),
+            status=data.get("status", "Unknown"),
+            connectors=[
+                self._parse_connector(c) for c in (data.get("connectors") or [])
+            ],
+        )
+
+    def _parse_location(self, data: dict) -> Location:
+        coords = data.get("coordinates") or {}
+        addr = data.get("address") or {}
+        acc = data.get("accessibility") or {}
+        return Location(
+            uid=data.get("uid", 0),
+            externalId=str(data.get("externalId", "")),
+            coordinates=Coordinates(
+                latitude=float(coords.get("latitude", 0)),
+                longitude=float(coords.get("longitude", 0)),
+            ),
+            operatorName=data.get("operatorName", ""),
+            address=Address(
+                streetAndNumber=addr.get("streetAndNumber", ""),
+                postalCode=addr.get("postalCode", ""),
+                city=addr.get("city", ""),
+                country=addr.get("country", ""),
+            ),
+            evses=[self._parse_evse(e) for e in (data.get("evses") or [])],
+            accessibilityV2=AccessibilityV2(status=acc.get("status", "")),
+            suboperatorName=data.get("suboperatorName", ""),
+            supportPhoneNumber=data.get("supportPhoneNumber", ""),
+            openTwentyFourSeven=bool(data.get("openTwentyFourSeven", True)),
+        )

--- a/custom_components/shell_recharge/config_flow.py
+++ b/custom_components/shell_recharge/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from asyncio import CancelledError
 from typing import Any
 
-import shellrecharge
 import voluptuous as vol
 from aiohttp.client_exceptions import ClientError
 from homeassistant import config_entries
@@ -16,10 +15,12 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
-from shellrecharge import LocationEmptyError, LocationValidationError
 from shellrecharge.user import LoginFailedError
 
+from .api import ShellEvApi, ShellEvAuthError, ShellEvLocationNotFoundError
 from .const import DOMAIN
+
+import shellrecharge
 
 RECHARGE_SCHEMA = vol.Schema(
     {
@@ -27,6 +28,10 @@ RECHARGE_SCHEMA = vol.Schema(
             vol.Schema(
                 {
                     vol.Optional("serial_number"): str,
+                    vol.Optional("client_id"): str,
+                    vol.Optional("client_secret"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.PASSWORD)
+                    ),
                 }
             ),
             {"collapsed": True},
@@ -51,7 +56,7 @@ RECHARGE_SCHEMA = vol.Schema(
 class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for shell_recharge_ev."""
 
-    VERSION = 3
+    VERSION = 4
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -62,33 +67,39 @@ class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="user", data_schema=RECHARGE_SCHEMA)
 
         try:
-            if user_input.get("public") and user_input["public"].get("serial_number"):
-                unique_id = user_input["public"]["serial_number"]
-                api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
+            pub = user_input.get("public") or {}
+            priv = user_input.get("private") or {}
+
+            if pub.get("serial_number") and pub.get("client_id") and pub.get("client_secret"):
+                unique_id = pub["serial_number"]
+                api = ShellEvApi(
+                    websession=async_get_clientsession(self.hass),
+                    client_id=pub["client_id"],
+                    client_secret=pub["client_secret"],
+                )
                 await api.location_by_id(unique_id)
-            elif (
-                user_input.get("private")
-                and user_input["private"].get("email")
-                and user_input["private"].get("password")
-            ):
-                unique_id = user_input["private"]["email"]
-                api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
-                user = await api.get_user(
+
+            elif priv.get("email") and priv.get("password"):
+                unique_id = priv["email"]
+                shell_api = shellrecharge.Api(websession=async_get_clientsession(self.hass))
+                user = await shell_api.get_user(
                     email=unique_id,
-                    pwd=user_input["private"]["password"],
+                    pwd=priv["password"],
                 )
                 user_input["private"]["api_key"] = user.cookies["tnm_api"]
+
             else:
                 errors["base"] = "missing_data"
                 return self.async_show_form(
                     step_id="user", data_schema=RECHARGE_SCHEMA, errors=errors
                 )
+
         except LoginFailedError:
             errors["base"] = "login_failed"
-        except LocationEmptyError:
+        except ShellEvAuthError:
+            errors["base"] = "auth_failed"
+        except ShellEvLocationNotFoundError:
             errors["base"] = "empty_response"
-        except LocationValidationError:
-            errors["base"] = "validation"
         except (ClientError, TimeoutError, CancelledError):
             errors["base"] = "cannot_connect"
 
@@ -96,7 +107,7 @@ class ShellRechargeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(unique_id)
             self._abort_if_unique_id_configured(updates=user_input)
             return self.async_create_entry(
-                title=f"Shell Recharge Charge Point ID {unique_id}",
+                title=f"Shell Recharge {unique_id}",
                 data=user_input,
             )
 

--- a/custom_components/shell_recharge/coordinator.py
+++ b/custom_components/shell_recharge/coordinator.py
@@ -6,10 +6,10 @@ from asyncio.exceptions import CancelledError
 from aiohttp.client_exceptions import ClientError
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from shellrecharge import Api, Location, LocationEmptyError
 from shellrecharge.user import AssetsEmptyError, DetailedChargePointEmptyError, User
 from shellrecharge.usermodels import DetailedAssets
 
+from .api import Location, ShellEvApi, ShellEvApiError, ShellEvAuthError
 from .const import DOMAIN, UPDATE_INTERVAL, SerialNumber
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,10 +31,7 @@ class ShellRechargeUserDataUpdateCoordinator(DataUpdateCoordinator[DetailedAsset
         self.api = api
 
     async def _async_update_data(self) -> DetailedAssets:
-        """Fetch data from API endpoint.
-
-        Fetches charge point information to cache for entities.
-        """
+        """Fetch data from API endpoint."""
         data = None
         try:
             data = await self.api.get_detailed_assets()
@@ -45,26 +42,22 @@ class ShellRechargeUserDataUpdateCoordinator(DataUpdateCoordinator[DetailedAsset
             _LOGGER.info("User has no charger(s)")
             raise UpdateFailed() from exc
         except CancelledError as exc:
-            _LOGGER.error(
-                "CancelledError occurred while fetching user's for charger(s)"
-            )
+            _LOGGER.error("CancelledError while fetching user charger(s)")
             raise UpdateFailed() from exc
         except TimeoutError as exc:
-            _LOGGER.error("TimeoutError occurred while fetching user's for charger(s)")
+            _LOGGER.error("TimeoutError while fetching user charger(s)")
             raise UpdateFailed() from exc
         except ClientError as exc:
-            _LOGGER.error("ClientError occurred while fetching user's for charger(s)")
+            _LOGGER.error("ClientError while fetching user charger(s)")
             raise UpdateFailed() from exc
         except Exception as exc:
             _LOGGER.error(
-                "Unexpected error occurred while fetching user's for charger(s): %s",
-                exc,
-                exc_info=True,
+                "Unexpected error fetching user charger(s): %s", exc, exc_info=True
             )
             raise UpdateFailed() from exc
 
         if data is None:
-            _LOGGER.error("API returned None data for user's charger(s)")
+            _LOGGER.error("API returned None data for user charger(s)")
             raise UpdateFailed("API returned None data")
 
         return data
@@ -81,10 +74,10 @@ class ShellRechargeUserDataUpdateCoordinator(DataUpdateCoordinator[DetailedAsset
 
 
 class ShellRechargePublicDataUpdateCoordinator(DataUpdateCoordinator[Location]):
-    """Handles data updates for public chargers."""
+    """Handles data updates for public chargers via the official Shell EV API."""
 
     def __init__(
-        self, hass: HomeAssistant, api: Api, serial_number: SerialNumber
+        self, hass: HomeAssistant, api: ShellEvApi, serial_number: SerialNumber
     ) -> None:
         """Initialize coordinator."""
         super().__init__(
@@ -97,41 +90,34 @@ class ShellRechargePublicDataUpdateCoordinator(DataUpdateCoordinator[Location]):
         self.serial_number = serial_number
 
     async def _async_update_data(self) -> Location:
-        """Fetch data from API endpoint.
-
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
+        """Fetch location data from the Shell EV API."""
         data = None
         try:
             data = await self.api.location_by_id(self.serial_number)
-        except LocationEmptyError as exc:
+        except ShellEvAuthError as exc:
             _LOGGER.error(
-                "Error fetching charger(s) %s: not found or serial is invalid",
-                self.serial_number,
+                "Authentication failed for Shell EV API. "
+                "Check your client_id and client_secret at developer.shell.com. Error: %s",
+                exc,
             )
-            raise UpdateFailed() from exc
+            raise UpdateFailed(str(exc)) from exc
+        except ShellEvApiError as exc:
+            _LOGGER.error(
+                "Error fetching charger %s: %s", self.serial_number, exc
+            )
+            raise UpdateFailed(str(exc)) from exc
         except CancelledError as exc:
-            _LOGGER.error(
-                "CancelledError occurred while fetching data for charger(s) %s",
-                self.serial_number,
-            )
+            _LOGGER.error("CancelledError while fetching charger %s", self.serial_number)
             raise UpdateFailed() from exc
         except TimeoutError as exc:
-            _LOGGER.error(
-                "TimeoutError occurred while fetching data for charger(s) %s",
-                self.serial_number,
-            )
+            _LOGGER.error("TimeoutError while fetching charger %s", self.serial_number)
             raise UpdateFailed() from exc
         except ClientError as exc:
-            _LOGGER.error(
-                "ClientError occurred while fetching data for charger(s) %s",
-                self.serial_number,
-            )
+            _LOGGER.error("ClientError while fetching charger %s", self.serial_number)
             raise UpdateFailed() from exc
         except Exception as exc:
             _LOGGER.error(
-                "Unexpected error occurred while fetching data for charger(s) %s: %s",
+                "Unexpected error fetching charger %s: %s",
                 self.serial_number,
                 exc,
                 exc_info=True,
@@ -139,10 +125,7 @@ class ShellRechargePublicDataUpdateCoordinator(DataUpdateCoordinator[Location]):
             raise UpdateFailed() from exc
 
         if data is None:
-            _LOGGER.error(
-                "API returned None data for charger(s) %s",
-                self.serial_number,
-            )
+            _LOGGER.error("API returned None data for charger %s", self.serial_number)
             raise UpdateFailed("API returned None data")
 
         return data

--- a/custom_components/shell_recharge/manifest.json
+++ b/custom_components/shell_recharge/manifest.json
@@ -13,5 +13,5 @@
   "requirements": [
     "shellrecharge==0.1.26"
   ],
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/custom_components/shell_recharge/sensor.py
+++ b/custom_components/shell_recharge/sensor.py
@@ -17,13 +17,13 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from shellrecharge.models import Location
 from shellrecharge.usermodels import DetailedAssets, DetailedChargePoint, DetailedEvse
 
 from . import (
     ShellRechargePublicDataUpdateCoordinator,
     ShellRechargeUserDataUpdateCoordinator,
 )
+from .api import EVSE_STATUS_OPTIONS, Location
 from .const import DOMAIN, EvseId, ShellRechargeEntityFeature
 
 _LOGGER = logging.getLogger(__name__)
@@ -263,11 +263,11 @@ class ShellRechargeSensor(
         self.coordinator = coordinator
         self.location: Location = self.coordinator.data
         self._attr_unique_id = f"{evse_id}-charger"
-        self._attr_attribution = "shellrecharge.com"
+        self._attr_attribution = "api.shell.com"
         self._attr_device_class = SensorDeviceClass.ENUM
         self._attr_native_unit_of_measurement = None
         self._attr_state_class = None
-        if hasattr(self.location, "suboperatorName") and self.location.suboperatorName:
+        if getattr(self.location, "suboperatorName", None):
             operator = self.location.suboperatorName
         else:
             operator = self.location.operatorName
@@ -281,7 +281,7 @@ class ShellRechargeSensor(
             entry_type=None,
             manufacturer=operator,
         )
-        self._attr_options = list(typing.get_args(shellrecharge.models.Status))
+        self._attr_options = EVSE_STATUS_OPTIONS
         self._read_coordinator_data()
 
     def _get_evse(self) -> Any:
@@ -292,7 +292,7 @@ class ShellRechargeSensor(
                     return evse
         return None
 
-    def _choose_icon(self, connectors: list[shellrecharge.models.Connector]) -> str:
+    def _choose_icon(self, connectors: list) -> str:
         iconmap: dict[str, str] = {
             "Type1": "mdi:ev-plug-type1",
             "Type2": "mdi:ev-plug-type2",
@@ -319,8 +319,8 @@ class ShellRechargeSensor(
             if evse:
                 self._attr_native_value = evse.status
                 self._attr_icon = self._choose_icon(evse.connectors)
-                connector = evse.connectors[0]
-                extra_data = {
+                connector = evse.connectors[0] if evse.connectors else None
+                extra_data: dict[str, Any] = {
                     "address": location.address.streetAndNumber,
                     "city": location.address.city,
                     "postal_code": location.address.postalCode,
@@ -330,25 +330,28 @@ class ShellRechargeSensor(
                     "operator_name": location.operatorName,
                     "suboperator_name": location.suboperatorName,
                     "support_phonenumber": location.supportPhoneNumber,
-                    "tariff_startfee": connector.tariff.startFee,
-                    "tariff_per_kwh": connector.tariff.perKWh,
-                    "tariff_per_minute": connector.tariff.perMinute,
-                    "tariff_currency": connector.tariff.currency,
-                    "tariff_updated": connector.tariff.updated,
-                    "tariff_updated_by": connector.tariff.updatedBy,
-                    "tariff_structure": connector.tariff.structure,
-                    "connector_power_type": connector.electricalProperties.powerType,
-                    "connector_voltage": connector.electricalProperties.voltage,
-                    "connector_ampere": connector.electricalProperties.amperage,
-                    "connector_max_power": connector.electricalProperties.maxElectricPower,
-                    "connector_fixed_cable": connector.fixedCable,
                     "accessibility": location.accessibilityV2.status,
                     "external_id": str(location.externalId),
                     "evse_id": str(evse.evseId),
                     "opentwentyfourseven": location.openTwentyFourSeven,
-                    # "opening_hours": location.openingHours,
-                    # "predicted_occupancies": location.predictedOccupancies,
                 }
+                if connector:
+                    extra_data.update(
+                        {
+                            "tariff_startfee": connector.tariff.startFee,
+                            "tariff_per_kwh": connector.tariff.perKWh,
+                            "tariff_per_minute": connector.tariff.perMinute,
+                            "tariff_currency": connector.tariff.currency,
+                            "tariff_updated": connector.tariff.updated,
+                            "tariff_updated_by": connector.tariff.updatedBy,
+                            "tariff_structure": connector.tariff.structure,
+                            "connector_power_type": connector.electricalProperties.powerType,
+                            "connector_voltage": connector.electricalProperties.voltage,
+                            "connector_ampere": connector.electricalProperties.amperage,
+                            "connector_max_power": connector.electricalProperties.maxElectricPower,
+                            "connector_fixed_cable": connector.fixedCable,
+                        }
+                    )
                 self._attr_extra_state_attributes = extra_data
         except AttributeError as err:
             _LOGGER.error(err)

--- a/custom_components/shell_recharge/strings.json
+++ b/custom_components/shell_recharge/strings.json
@@ -4,10 +4,11 @@
       "already_configured": "Device is already configured"
     },
     "error": {
+      "auth_failed": "Authentication failed. Check your Client ID and Client Secret at developer.shell.com.",
       "cannot_connect": "Failed to connect",
-      "empty_response": "Empty response from shellrecharge.com. Either invalid SERIAL-NUMBER or no data found for it.",
+      "empty_response": "Location not found. Check the SERIAL-NUMBER / external location ID.",
       "login_failed": "Login failed, please verify email and password are correct.",
-      "missing_data": "Please provide either a serial number or email and password.",
+      "missing_data": "Please fill in either the public charge point fields (with Client ID and Client Secret) or the private charge point fields.",
       "unknown": "Unexpected error"
     },
     "step": {
@@ -22,7 +23,9 @@
           },
           "public": {
             "data": {
-              "serial_number": "SERIAL-NUMBER (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)"
+              "serial_number": "Location external ID (e.g. 0F80EA26-5F5D-4728-B5E5-268BE55B9191)",
+              "client_id": "Client ID (from developer.shell.com)",
+              "client_secret": "Client Secret (from developer.shell.com)"
             },
             "name": "Public charge point"
           }


### PR DESCRIPTION
The old map API (ui-map.shellrecharge.com/api/map/v2) now blocks server-side requests with 403 "Host not in allowlist". This commit migrates the public charger path to the official Shell EV API which uses OAuth2 client credentials.

Changes:
- Add api.py: async aiohttp wrapper for api.shell.com/ev/v1 with OAuth2 token caching and data models compatible with the existing sensor interface
- config_flow: add client_id and client_secret fields for public chargers; bump config version to 4 with automatic migration from v2/v3
- coordinator: replace shellrecharge.Api with ShellEvApi for public chargers
- sensor: use new EVSE_STATUS_OPTIONS and api.Location; keep private charger code unchanged (shellrecharge package, different endpoints)
- manifest: bump integration version to 2.0.0
- strings/README: document new developer.shell.com credential requirement

Users with existing public charger entries will need to reconfigure and add their Client ID and Client Secret obtained from developer.shell.com. Private charger entries are unaffected.

https://claude.ai/code/session_01ARdimeSqkXXRcegATw3CY5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Now integrates with the official Shell EV API for public charger management

* **Changes**
  * Public charger configuration process updated: requires Shell EV API credentials (Client ID and Client Secret) and location external ID instead of charger serial number
  * Discontinued support for the unofficial map API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->